### PR TITLE
Added support for ObjC and Swift libraries

### DIFF
--- a/loader/include/ObjCRuntime.h
+++ b/loader/include/ObjCRuntime.h
@@ -1,0 +1,56 @@
+// Pulled from here
+// https://github.com/mull-project/llvm-jit-objc/tree/master/llvm-jit-objc/src/include
+// as POC from article at https://stanislaw.github.io/2018-09-03-llvm-jit-objc-and-swift-knowledge-dump.html
+
+#pragma once
+
+#include "ObjCType.h"
+#include <objc/objc.h>
+
+#include <queue>
+#include <vector>
+#include <set>
+
+#pragma mark -
+
+namespace mull
+{
+  namespace objc
+  {
+
+    class Runtime
+    {
+      std::queue<class64_t **> classesToRegister;
+
+      std::vector<class64_t *> classRefs;
+      std::vector<class64_t *> metaclassRefs;
+
+      std::set<Class> runtimeClasses;
+      std::vector<std::pair<class64_t **, Class>> oldAndNewClassesMap;
+
+      Class registerOneClass(class64_t **classrefPtr, Class superclass);
+      void parsePropertyAttributes(const char *const attributesStr,
+                                   char *const stringStorage,
+                                   objc_property_attribute_t *attributes,
+                                   size_t *count);
+
+    public:
+      ~Runtime();
+
+      void registerSelectors(void *selRefsSectionPtr,
+                             uintptr_t selRefsSectionSize);
+
+      void addClassesFromSection(void *sectionPtr,
+                                 uintptr_t sectionSize);
+      void addClassesFromClassRefsSection(void *sectionPtr,
+                                          uintptr_t sectionSize);
+      void addClassesFromSuperclassRefsSection(void *sectionPtr,
+                                               uintptr_t sectionSize);
+      void addCategoriesFromSection(void *sectionPtr,
+                                    uintptr_t sectionSize);
+
+      void registerClasses();
+    };
+
+  }
+}

--- a/loader/include/ObjCType.h
+++ b/loader/include/ObjCType.h
@@ -1,0 +1,1016 @@
+// Pulled from here
+// https://github.com/mull-project/llvm-jit-objc/tree/master/llvm-jit-objc/src/include
+// as POC from article at https://stanislaw.github.io/2018-09-03-llvm-jit-objc-and-swift-knowledge-dump.html
+
+#pragma once
+
+#include <objc/runtime.h>
+
+#include <string>
+#include <cassert>
+
+#ifndef _HERE_OBJC_RUNTIME_CONFIG_H_
+#define _HERE_OBJC_RUNTIME_CONFIG_H_
+
+// Define SUPPORT_GC_COMPAT=1 to enable compatibility where GC once was.
+// OBJC_NO_GC and OBJC_NO_GC_API in objc-api.h mean something else.
+#if !TARGET_OS_OSX
+#define SUPPORT_GC_COMPAT 0
+#else
+#define SUPPORT_GC_COMPAT 1
+#endif
+
+// Define SUPPORT_ZONES=1 to enable malloc zone support in NXHashTable.
+#if !TARGET_OS_OSX
+#define SUPPORT_ZONES 0
+#else
+#define SUPPORT_ZONES 1
+#endif
+
+// Define SUPPORT_MOD=1 to use the mod operator in NXHashTable and objc-sel-set
+#if defined(__arm__)
+#define SUPPORT_MOD 0
+#else
+#define SUPPORT_MOD 1
+#endif
+
+// Define SUPPORT_PREOPT=1 to enable dyld shared cache optimizations
+#if TARGET_OS_WIN32 || TARGET_OS_SIMULATOR
+#define SUPPORT_PREOPT 0
+#else
+#define SUPPORT_PREOPT 1
+#endif
+
+// Define SUPPORT_TAGGED_POINTERS=1 to enable tagged pointer objects
+// Be sure to edit tagged pointer SPI in objc-internal.h as well.
+#if !(__OBJC2__ && __LP64__)
+#define SUPPORT_TAGGED_POINTERS 0
+#else
+#define SUPPORT_TAGGED_POINTERS 1
+#endif
+
+// Define SUPPORT_MSB_TAGGED_POINTERS to use the MSB
+// as the tagged pointer marker instead of the LSB.
+// Be sure to edit tagged pointer SPI in objc-internal.h as well.
+#if !SUPPORT_TAGGED_POINTERS || !TARGET_OS_IPHONE
+#define SUPPORT_MSB_TAGGED_POINTERS 0
+#else
+#define SUPPORT_MSB_TAGGED_POINTERS 1
+#endif
+
+// Define SUPPORT_INDEXED_ISA=1 on platforms that store the class in the isa
+// field as an index into a class table.
+// Note, keep this in sync with any .s files which also define it.
+// Be sure to edit objc-abi.h as well.
+#if __ARM_ARCH_7K__ >= 2
+#define SUPPORT_INDEXED_ISA 1
+#else
+#define SUPPORT_INDEXED_ISA 0
+#endif
+
+// Define SUPPORT_PACKED_ISA=1 on platforms that store the class in the isa
+// field as a maskable pointer with other data around it.
+#if (!__LP64__ || TARGET_OS_WIN32 || TARGET_OS_SIMULATOR)
+#define SUPPORT_PACKED_ISA 0
+#else
+#define SUPPORT_PACKED_ISA 1
+#endif
+
+// Define SUPPORT_NONPOINTER_ISA=1 on any platform that may store something
+// in the isa field that is not a raw pointer.
+#if !SUPPORT_INDEXED_ISA && !SUPPORT_PACKED_ISA
+#define SUPPORT_NONPOINTER_ISA 0
+#else
+#define SUPPORT_NONPOINTER_ISA 1
+#endif
+
+// Define SUPPORT_FIXUP=1 to repair calls sites for fixup dispatch.
+// Fixup messaging itself is no longer supported.
+// Be sure to edit objc-abi.h as well (objc_msgSend*_fixup)
+#if !(defined(__x86_64__) && (TARGET_OS_OSX || TARGET_OS_SIMULATOR))
+#define SUPPORT_FIXUP 0
+#else
+#define SUPPORT_FIXUP 1
+#endif
+
+// Define SUPPORT_ZEROCOST_EXCEPTIONS to use "zero-cost" exceptions for OBJC2.
+// Be sure to edit objc-exception.h as well (objc_add/removeExceptionHandler)
+#if !__OBJC2__ || (defined(__arm__) && __USING_SJLJ_EXCEPTIONS__)
+#define SUPPORT_ZEROCOST_EXCEPTIONS 0
+#else
+#define SUPPORT_ZEROCOST_EXCEPTIONS 1
+#endif
+
+// Define SUPPORT_ALT_HANDLERS if you're using zero-cost exceptions
+// but also need to support AppKit's alt-handler scheme
+// Be sure to edit objc-exception.h as well (objc_add/removeExceptionHandler)
+#if !SUPPORT_ZEROCOST_EXCEPTIONS || TARGET_OS_IPHONE || TARGET_OS_EMBEDDED
+#define SUPPORT_ALT_HANDLERS 0
+#else
+#define SUPPORT_ALT_HANDLERS 1
+#endif
+
+// Define SUPPORT_RETURN_AUTORELEASE to optimize autoreleased return values
+#if TARGET_OS_WIN32
+#define SUPPORT_RETURN_AUTORELEASE 0
+#else
+#define SUPPORT_RETURN_AUTORELEASE 1
+#endif
+
+// Define SUPPORT_STRET on architectures that need separate struct-return ABI.
+#if defined(__arm64__)
+#define SUPPORT_STRET 0
+#else
+#define SUPPORT_STRET 1
+#endif
+
+// Define SUPPORT_MESSAGE_LOGGING to enable NSObjCMessageLoggingEnabled
+#if TARGET_OS_WIN32 || TARGET_OS_EMBEDDED
+#define SUPPORT_MESSAGE_LOGGING 0
+#else
+#define SUPPORT_MESSAGE_LOGGING 1
+#endif
+
+// Define SUPPORT_QOS_HACK to work around deadlocks due to QoS bugs.
+#if !__OBJC2__ || TARGET_OS_WIN32
+#define SUPPORT_QOS_HACK 0
+#else
+#define SUPPORT_QOS_HACK 1
+#endif
+
+// OBJC_INSTRUMENTED controls whether message dispatching is dynamically
+// monitored.  Monitoring introduces substantial overhead.
+// NOTE: To define this condition, do so in the build command, NOT by
+// uncommenting the line here.  This is because objc-class.h heeds this
+// condition, but objc-class.h can not #include this file (objc-config.h)
+// because objc-class.h is public and objc-config.h is not.
+// #define OBJC_INSTRUMENTED
+
+#endif
+
+static inline void *
+memdup(const void *mem, size_t len)
+{
+  void *dup = malloc(len);
+  memcpy(dup, mem, len);
+  return dup;
+}
+
+namespace mull
+{
+  namespace objc
+  {
+
+    struct method64_t
+    {
+      SEL name;          /* SEL (64-bit pointer) */
+      const char *types; /* const char * (64-bit pointer) */
+      uint64_t imp;      /* IMP (64-bit pointer) */
+
+      struct SortBySELAddress : public std::binary_function<const method64_t &,
+                                                            const method64_t &, bool>
+      {
+        bool operator()(const method64_t &lhs,
+                        const method64_t &rhs)
+        {
+          return lhs.name < rhs.name;
+        }
+      };
+
+      std::string getDebugDescription(int level = 0) const;
+    };
+
+    struct method_list64_t
+    {
+      uint32_t entsize;
+      uint32_t count;
+      struct method64_t first; // These structures follow inline
+
+      const method64_t *getFirstMethodPointer() const
+      {
+        assert((&this->entsize + 2) == (void *)(&this->first));
+        return (const method64_t *)(&this->first);
+      }
+
+      std::string getDebugDescription(int level = 0) const;
+    };
+
+    struct ivar64_t
+    {
+      void *offset;     /* uintptr_t * (64-bit pointer) */
+      const char *name; /* const char * (64-bit pointer) */
+      const char *type; /* const char * (64-bit pointer) */
+      uint32_t alignment;
+      uint32_t size;
+    };
+
+    struct ivar_list64_t
+    {
+      uint32_t entsize;
+      uint32_t count;
+      struct ivar64_t first;
+    };
+
+    struct objc_property64
+    {
+      const char *name;       /* const char * (64-bit pointer) */
+      const char *attributes; /* const char * (64-bit pointer) */
+    };
+
+    struct objc_property_list64
+    {
+      uint32_t entsize;
+      uint32_t count;
+      struct objc_property64 first;
+    };
+
+    struct class_ro64_t
+    {
+      uint32_t flags;
+      uint32_t instanceStart;
+      uint32_t instanceSize;
+      uint32_t reserved;
+      uint64_t ivarLayout;                               // const uint8_t * (64-bit pointer)
+      const char *name;                                  // const char * (64-bit pointer)
+      method_list64_t *baseMethods;                      // const method_list_t * (64-bit pointer)
+      uint64_t baseProtocols;                            // const protocol_list_t * (64-bit pointer)
+      const ivar_list64_t *ivars;                        // const ivar_list_t * (64-bit pointer)
+      uint64_t weakIvarLayout;                           // const uint8_t * (64-bit pointer)
+      const struct objc_property_list64 *baseProperties; // const struct objc_property_list (64-bit pointer)
+
+      bool isMetaClass() const
+      {
+        return (flags & 0x1) == 1;
+      }
+
+      const char *getName() const
+      {
+        return (const char *)name;
+      }
+
+      method_list64_t *getMethodListPtr() const
+      {
+        return baseMethods;
+      }
+
+      std::string getDebugDescription(int level = 0) const;
+    };
+
+    enum Description
+    {
+      Clazz = 0,
+      IsaOrSuperclass = 1
+    };
+
+    struct class64_t
+    {
+      class64_t *isa;        // class64_t * (64-bit pointer)
+      class64_t *superclass; // class64_t * (64-bit pointer)
+      uint64_t cache;        // Cache (64-bit pointer)
+      uint64_t vtable;       // IMP * (64-bit pointer)
+      class_ro64_t *data;    // class_ro64_t * (64-bit pointer)
+
+      class64_t *getIsaPointer() const
+      {
+        return (class64_t *)isa;
+      }
+      class64_t *getSuperclassPointer() const
+      {
+        return (class64_t *)superclass;
+      }
+      class_ro64_t *getDataPointer() const
+      {
+#define FAST_DATA_MASK 0x00007ffffffffff8UL
+
+        return (class_ro64_t *)((uintptr_t)data & FAST_DATA_MASK);
+        //    return (class_ro64_t *)data;
+      }
+
+      std::string getDebugDescription(Description = Clazz) const;
+      bool isFastDataMask() const
+      {
+        // #define FAST_DATA_MASK          0x00007ffffffffff8ULL
+
+        return (uintptr_t)data & FAST_DATA_MASK;
+      }
+
+      bool isSwift() const
+      {
+#define FAST_IS_SWIFT (1UL << 0)
+
+        return (uintptr_t)data & FAST_IS_SWIFT;
+      }
+    };
+
+  }
+} // namespace mull { namespace objc {
+
+template <typename Element, typename List, uint32_t FlagMask>
+struct entsize_list_tt
+{
+  uint32_t entsizeAndFlags;
+  uint32_t count;
+  Element first;
+
+  uint32_t entsize() const
+  {
+    return entsizeAndFlags & ~FlagMask;
+  }
+  uint32_t flags() const
+  {
+    return entsizeAndFlags & FlagMask;
+  }
+
+  Element &getOrEnd(uint32_t i) const
+  {
+    assert(i <= count);
+    return *(Element *)((uint8_t *)&first + i * entsize());
+  }
+  Element &get(uint32_t i) const
+  {
+    assert(i < count);
+    return getOrEnd(i);
+  }
+
+  size_t byteSize() const
+  {
+    return sizeof(*this) + (count - 1) * entsize();
+  }
+
+  List *duplicate() const
+  {
+    return (List *)memdup(this, this->byteSize());
+  }
+
+  struct iterator;
+  const iterator begin() const
+  {
+    return iterator(*static_cast<const List *>(this), 0);
+  }
+  iterator begin()
+  {
+    return iterator(*static_cast<const List *>(this), 0);
+  }
+  const iterator end() const
+  {
+    return iterator(*static_cast<const List *>(this), count);
+  }
+  iterator end()
+  {
+    return iterator(*static_cast<const List *>(this), count);
+  }
+
+  struct iterator
+  {
+    uint32_t entsize;
+    uint32_t index; // keeping track of this saves a divide in operator-
+    Element *element;
+
+    typedef std::random_access_iterator_tag iterator_category;
+    typedef Element value_type;
+    typedef ptrdiff_t difference_type;
+    typedef Element *pointer;
+    typedef Element &reference;
+
+    iterator() {}
+
+    iterator(const List &list, uint32_t start = 0)
+        : entsize(list.entsize()), index(start), element(&list.getOrEnd(start))
+    {
+    }
+
+    const iterator &operator+=(ptrdiff_t delta)
+    {
+      element = (Element *)((uint8_t *)element + delta * entsize);
+      index += (int32_t)delta;
+      return *this;
+    }
+    const iterator &operator-=(ptrdiff_t delta)
+    {
+      element = (Element *)((uint8_t *)element - delta * entsize);
+      index -= (int32_t)delta;
+      return *this;
+    }
+    const iterator operator+(ptrdiff_t delta) const
+    {
+      return iterator(*this) += delta;
+    }
+    const iterator operator-(ptrdiff_t delta) const
+    {
+      return iterator(*this) -= delta;
+    }
+
+    iterator &operator++()
+    {
+      *this += 1;
+      return *this;
+    }
+    iterator &operator--()
+    {
+      *this -= 1;
+      return *this;
+    }
+    iterator operator++(int)
+    {
+      iterator result(*this);
+      *this += 1;
+      return result;
+    }
+    iterator operator--(int)
+    {
+      iterator result(*this);
+      *this -= 1;
+      return result;
+    }
+
+    ptrdiff_t operator-(const iterator &rhs) const
+    {
+      return (ptrdiff_t)this->index - (ptrdiff_t)rhs.index;
+    }
+
+    Element &operator*() const { return *element; }
+    Element *operator->() const { return element; }
+
+    operator Element &() const { return *element; }
+
+    bool operator==(const iterator &rhs) const
+    {
+      return this->element == rhs.element;
+    }
+    bool operator!=(const iterator &rhs) const
+    {
+      return this->element != rhs.element;
+    }
+
+    bool operator<(const iterator &rhs) const
+    {
+      return this->element < rhs.element;
+    }
+    bool operator>(const iterator &rhs) const
+    {
+      return this->element > rhs.element;
+    }
+  };
+};
+
+// Two bits of entsize are used for fixup markers.
+struct method_list_t : entsize_list_tt<mull::objc::method64_t, method_list_t, 0x3>
+{
+  bool isFixedUp() const;
+  void setFixedUp()
+  {
+    static uint32_t fixed_up_method_list = 3;
+
+    //    assert(!isFixedUp());
+    entsizeAndFlags = entsize() | fixed_up_method_list;
+  }
+
+  uint32_t indexOfMethod(const mull::objc::method64_t *meth) const
+  {
+    uint32_t i =
+        (uint32_t)(((uintptr_t)meth - (uintptr_t)this) / entsize());
+    assert(i < count);
+    return i;
+  }
+};
+
+/***********************************************************************
+ * list_array_tt<Element, List>
+ * Generic implementation for metadata that can be augmented by categories.
+ *
+ * Element is the underlying metadata type (e.g. method_t)
+ * List is the metadata's list type (e.g. method_list_t)
+ *
+ * A list_array_tt has one of three values:
+ * - empty
+ * - a pointer to a single list
+ * - an array of pointers to lists
+ *
+ * countLists/beginLists/endLists iterate the metadata lists
+ * count/begin/end iterate the underlying metadata elements
+ **********************************************************************/
+template <typename Element, typename List>
+class list_array_tt
+{
+  struct array_t
+  {
+    uint32_t count;
+    List *lists[0];
+
+    static size_t byteSize(uint32_t count)
+    {
+      return sizeof(array_t) + count * sizeof(lists[0]);
+    }
+    size_t byteSize()
+    {
+      return byteSize(count);
+    }
+  };
+
+protected:
+  class iterator
+  {
+    List **lists;
+    List **listsEnd;
+    typename List::iterator m, mEnd;
+
+  public:
+    iterator(List **begin, List **end)
+        : lists(begin), listsEnd(end)
+    {
+      if (begin != end)
+      {
+        m = (*begin)->begin();
+        mEnd = (*begin)->end();
+      }
+    }
+
+    const Element &operator*() const
+    {
+      return *m;
+    }
+    Element &operator*()
+    {
+      return *m;
+    }
+
+    bool operator!=(const iterator &rhs) const
+    {
+      if (lists != rhs.lists)
+        return true;
+      if (lists == listsEnd)
+        return false; // m is undefined
+      if (m != rhs.m)
+        return true;
+      return false;
+    }
+
+    const iterator &operator++()
+    {
+      assert(m != mEnd);
+      m++;
+      if (m == mEnd)
+      {
+        assert(lists != listsEnd);
+        lists++;
+        if (lists != listsEnd)
+        {
+          m = (*lists)->begin();
+          mEnd = (*lists)->end();
+        }
+      }
+      return *this;
+    }
+  };
+
+private:
+  union
+  {
+    List *list;
+    uintptr_t arrayAndFlag;
+  };
+
+  bool hasArray() const
+  {
+    return arrayAndFlag & 1;
+  }
+
+  array_t *array()
+  {
+    return (array_t *)(arrayAndFlag & ~1);
+  }
+
+  void setArray(array_t *array)
+  {
+    arrayAndFlag = (uintptr_t)array | 1;
+  }
+
+public:
+  uint32_t count()
+  {
+    uint32_t result = 0;
+    for (auto lists = beginLists(), end = endLists();
+         lists != end;
+         ++lists)
+    {
+      result += (*lists)->count;
+    }
+    return result;
+  }
+
+  iterator begin()
+  {
+    return iterator(beginLists(), endLists());
+  }
+
+  iterator end()
+  {
+    List **e = endLists();
+    return iterator(e, e);
+  }
+
+  uint32_t countLists()
+  {
+    if (hasArray())
+    {
+      return array()->count;
+    }
+    else if (list)
+    {
+      return 1;
+    }
+    else
+    {
+      return 0;
+    }
+  }
+
+  List **beginLists()
+  {
+    if (hasArray())
+    {
+      return array()->lists;
+    }
+    else
+    {
+      return &list;
+    }
+  }
+
+  List **endLists()
+  {
+    if (hasArray())
+    {
+      return array()->lists + array()->count;
+    }
+    else if (list)
+    {
+      return &list + 1;
+    }
+    else
+    {
+      return &list;
+    }
+  }
+
+  void attachLists(List *const *addedLists, uint32_t addedCount)
+  {
+    if (addedCount == 0)
+      return;
+
+    if (hasArray())
+    {
+      // many lists -> many lists
+      uint32_t oldCount = array()->count;
+      uint32_t newCount = oldCount + addedCount;
+      setArray((array_t *)realloc(array(), array_t::byteSize(newCount)));
+      array()->count = newCount;
+      memmove(array()->lists + addedCount, array()->lists,
+              oldCount * sizeof(array()->lists[0]));
+      memcpy(array()->lists, addedLists,
+             addedCount * sizeof(array()->lists[0]));
+    }
+    else if (!list && addedCount == 1)
+    {
+      // 0 lists -> 1 list
+      list = addedLists[0];
+    }
+    else
+    {
+      // 1 list -> many lists
+      List *oldList = list;
+      uint32_t oldCount = oldList ? 1 : 0;
+      uint32_t newCount = oldCount + addedCount;
+      setArray((array_t *)malloc(array_t::byteSize(newCount)));
+      array()->count = newCount;
+      if (oldList)
+        array()->lists[addedCount] = oldList;
+      memcpy(array()->lists, addedLists,
+             addedCount * sizeof(array()->lists[0]));
+    }
+  }
+
+  void tryFree()
+  {
+    if (hasArray())
+    {
+      for (uint32_t i = 0; i < array()->count; i++)
+      {
+        try_free(array()->lists[i]);
+      }
+      try_free(array());
+    }
+    else if (list)
+    {
+      try_free(list);
+    }
+  }
+
+  template <typename Result>
+  Result duplicate()
+  {
+    Result result;
+
+    if (hasArray())
+    {
+      array_t *a = array();
+      result.setArray((array_t *)memdup(a, a->byteSize()));
+      for (uint32_t i = 0; i < a->count; i++)
+      {
+        result.array()->lists[i] = a->lists[i]->duplicate();
+      }
+    }
+    else if (list)
+    {
+      result.list = list->duplicate();
+    }
+    else
+    {
+      result.list = nil;
+    }
+
+    return result;
+  }
+};
+
+class method_array_t : public list_array_tt<mull::objc::method64_t, method_list_t>
+{
+  typedef list_array_tt<mull::objc::method64_t, method_list_t> Super;
+
+public:
+  method_list_t **beginCategoryMethodLists()
+  {
+    return beginLists();
+  }
+
+  method_list_t **endCategoryMethodLists(Class cls);
+
+  method_array_t duplicate()
+  {
+    return Super::duplicate<method_array_t>();
+  }
+};
+
+//  struct method_array_t {
+//    uint32_t count;
+//    method64_t **lists;
+//  };
+
+struct property_t
+{
+  const char *name;
+  const char *attributes;
+};
+
+struct property_list_t : entsize_list_tt<property_t, property_list_t, 0>
+{
+};
+
+class property_array_t : public list_array_tt<property_t, property_list_t>
+{
+  typedef list_array_tt<property_t, property_list_t> Super;
+
+public:
+  property_array_t duplicate()
+  {
+    return Super::duplicate<property_array_t>();
+  }
+};
+typedef uintptr_t protocol_ref_t; // protocol_t *, but unremapped
+
+struct protocol_list_t
+{
+  // count is 64-bit by accident.
+  uintptr_t count;
+  protocol_ref_t list[0]; // variable-size
+
+  size_t byteSize() const
+  {
+    return sizeof(*this) + count * sizeof(list[0]);
+  }
+
+  protocol_list_t *duplicate() const
+  {
+    return (protocol_list_t *)memdup(this, this->byteSize());
+  }
+
+  typedef protocol_ref_t *iterator;
+  typedef const protocol_ref_t *const_iterator;
+
+  const_iterator begin() const
+  {
+    return list;
+  }
+  iterator begin()
+  {
+    return list;
+  }
+  const_iterator end() const
+  {
+    return list + count;
+  }
+  iterator end()
+  {
+    return list + count;
+  }
+};
+
+class protocol_array_t : public list_array_tt<protocol_ref_t, protocol_list_t>
+{
+  typedef list_array_tt<protocol_ref_t, protocol_list_t> Super;
+
+public:
+  protocol_array_t duplicate()
+  {
+    return Super::duplicate<protocol_array_t>();
+  }
+};
+
+struct here_class_rw_t
+{
+  // Be warned that Symbolication knows the layout of this structure.
+  uint32_t flags;
+  uint32_t version;
+
+  mull::objc::class_ro64_t *ro;
+
+  method_array_t methods;
+  property_array_t properties;
+  protocol_array_t protocols;
+
+  Class firstSubclass;
+  Class nextSiblingClass;
+
+  char *demangledName;
+
+  // #if SUPPORT_INDEXED_ISA
+  //     uint32_t index;
+  // #endif
+};
+struct class_data_bits_t
+{
+
+  // Values are the FAST_ flags above.
+  uintptr_t bits;
+
+public:
+  here_class_rw_t *data()
+  {
+    return (here_class_rw_t *)(bits & FAST_DATA_MASK);
+  }
+
+  void setData(here_class_rw_t *newData)
+  {
+    //      assert(!data()  ||  (newData->flags & (RW_REALIZING | RW_FUTURE)));
+    // Set during realization or construction only. No locking needed.
+    // Use a store-release fence because there may be concurrent
+    // readers of data and data's contents.
+    uintptr_t newBits = (bits & ~FAST_DATA_MASK) | (uintptr_t)newData;
+    bits = newBits;
+  }
+
+  bool isSwift()
+  {
+    return getBit(FAST_IS_SWIFT);
+  }
+  bool setSwift()
+  {
+    setBits(FAST_IS_SWIFT);
+    return true;
+  }
+
+  bool getBit(uintptr_t bit)
+  {
+    return bits & bit;
+  }
+
+  void setBits(uintptr_t set)
+  {
+    bits = bits | set;
+  }
+};
+
+#define RO_META (1 << 0)
+#define RW_REALIZED (1 << 31)
+
+struct cache_t
+{
+  uintptr_t __unused_buckets;
+  uint32_t _mask;
+  uint32_t _occupied;
+};
+
+union isa_t
+{
+  isa_t() {}
+  isa_t(uintptr_t value) : bits(value) {}
+
+  Class cls;
+  uintptr_t bits;
+};
+
+struct here_objc_object
+{
+  isa_t isa;
+
+public:
+  Class ISA()
+  {
+#define ISA_MASK 0x00007ffffffffff8ULL
+
+    //    assert(!isTaggedPointer());
+#if SUPPORT_INDEXED_ISA
+    if (ISA.nonpointer)
+    {
+      uintptr_t slot = isa.indexcls;
+      return classForIndex((unsigned)slot);
+    }
+    return (Class)isa.bits;
+#else
+    return (Class)(((uintptr_t)isa.bits) & ISA_MASK);
+#endif
+  }
+};
+
+struct here_objc_class : public here_objc_object
+{
+  Class superclass;
+  cache_t cache;
+  class_data_bits_t bits; // class_rw_t * plus custom rr/alloc flags
+
+  void setInstanceSize(uint32_t newSize)
+  {
+    assert(isRealized());
+    if (newSize != data()->ro->instanceSize)
+    {
+
+#define RW_COPIED_RO (1 << 27)
+
+      assert(data()->flags & RW_COPIED_RO);
+      *const_cast<uint32_t *>(&data()->ro->instanceSize) = newSize;
+    }
+    //    bits.setFastInstanceSize(newSize);
+  }
+
+  here_class_rw_t *data()
+  {
+    return bits.data();
+  }
+
+  void setData(here_class_rw_t *newData)
+  {
+    bits.setData(newData);
+  }
+
+  bool isSwift()
+  {
+    return bits.isSwift();
+  }
+  void setSwift()
+  {
+    bits.setSwift();
+  }
+  bool isRealized()
+  {
+    return data()->flags & RW_REALIZED;
+  }
+  bool isMetaClass()
+  {
+    assert(this);
+    assert(isRealized());
+    return data()->ro->flags & RO_META;
+  }
+};
+
+OBJC_EXPORT const uintptr_t objc_debug_isa_class_mask;
+
+struct here_swift_class_t : here_objc_class
+{
+  uint32_t flags;
+  uint32_t instanceAddressOffset;
+  uint32_t instanceSize;
+  uint16_t instanceAlignMask;
+  uint16_t reserved;
+
+  uint32_t classSize;
+  uint32_t classAddressOffset;
+  void *description;
+  // ...
+
+  void *baseAddress()
+  {
+    return (void *)((uint8_t *)this - classAddressOffset);
+  }
+};
+
+struct category_t
+{
+  const char *name;
+  mull::objc::class64_t *cls;
+  struct method_list_t *instanceMethods;
+  struct method_list_t *classMethods;
+  struct protocol_list_t *protocols;
+  struct property_list_t *instanceProperties;
+  // Fields below this point are not always present on disk.
+  struct property_list_t *_classProperties;
+};

--- a/loader/src/ObjCRuntime.cpp
+++ b/loader/src/ObjCRuntime.cpp
@@ -1,0 +1,336 @@
+// Pulled from here
+// https://github.com/mull-project/llvm-jit-objc/tree/master/llvm-jit-objc/src/include
+// as POC from article at https://stanislaw.github.io/2018-09-03-llvm-jit-objc-and-swift-knowledge-dump.html
+
+#include "ObjCRuntime.h"
+
+#include <objc/message.h>
+
+#include <iostream>
+#include <inttypes.h>
+
+extern "C" Class objc_readClassPair(Class bits, const struct objc_image_info *info);
+
+namespace mull
+{
+  namespace objc
+  {
+
+    bool objc_classIsRegistered(Class cls)
+    {
+      int numRegisteredClasses = objc_getClassList(NULL, 0);
+
+      Class *classes = (Class *)malloc(sizeof(Class) * numRegisteredClasses);
+
+      numRegisteredClasses = objc_getClassList(classes, numRegisteredClasses);
+
+      for (int i = 0; i < numRegisteredClasses; i++)
+      {
+        if (classes[i] == cls)
+        {
+          free(classes);
+          return true;
+        }
+      }
+
+      free(classes);
+      return false;
+    }
+
+    mull::objc::Runtime::~Runtime()
+    {
+      for (const Class &clz : runtimeClasses)
+      {
+
+        objc_disposeClassPair(clz);
+
+        // assert(objc_classIsRegistered(clz) == false);
+      }
+    }
+
+    void mull::objc::Runtime::registerSelectors(void *selRefsSectionPtr,
+                                                uintptr_t selRefsSectionSize)
+    {
+      uint8_t *sectionStart = (uint8_t *)selRefsSectionPtr;
+
+      for (uint8_t *cursor = sectionStart;
+           cursor < (sectionStart + selRefsSectionSize);
+           cursor = cursor + sizeof(SEL))
+      {
+        SEL *selector = (SEL *)cursor;
+
+        // TODO: memory padded/aligned by JIT.
+        if (*selector == NULL)
+        {
+          continue;
+        }
+        const char *name = sel_getName(*selector);
+
+        *selector = sel_registerName(name);
+      }
+    }
+
+    void mull::objc::Runtime::addClassesFromSection(void *sectionPtr,
+                                                    uintptr_t sectionSize)
+    {
+
+      class64_t **classes = (class64_t **)sectionPtr;
+
+      uint32_t count = sectionSize / 8;
+      // 16 is "8 + alignment" (don't know yet what alignment is for).
+      for (uintptr_t i = 0; i < count / 2; i += 1)
+      {
+        class64_t **clzPointerRef = &classes[i];
+        class64_t *clzPointer = *clzPointerRef;
+
+        classesToRegister.push(clzPointerRef);
+      }
+    }
+
+    void mull::objc::Runtime::addClassesFromClassRefsSection(void *sectionPtr,
+                                                             uintptr_t sectionSize)
+    {
+
+      Class *classrefs = (Class *)sectionPtr;
+      uint32_t count = sectionSize / 8;
+
+      for (uint32_t i = 0; i < count / 2; i++)
+      {
+        Class *classrefPtr = (&classrefs[i]);
+        const char *className = object_getClassName((id)*classrefPtr);
+        // assert(className);
+
+        Class newClz = objc_getRequiredClass(className);
+        // assert(class_isMetaClass(newClz) == false);
+
+        if (*classrefPtr != newClz)
+        {
+          *classrefPtr = objc_getRequiredClass(className);
+        }
+      }
+    }
+
+    void mull::objc::Runtime::addClassesFromSuperclassRefsSection(void *sectionPtr,
+                                                                  uintptr_t sectionSize)
+    {
+
+      Class *classrefs = (Class *)sectionPtr;
+      uint32_t count = sectionSize / 8;
+
+      for (uint32_t i = 0; i < count / 2; i++)
+      {
+        int refType = 0; // 0 - unknown, 1 - class, 2 - metaclass
+
+        Class *classrefPtr = (&classrefs[i]);
+        Class classref = *classrefPtr;
+
+        class64_t *ref = NULL;
+        for (auto &clref : classRefs)
+        {
+          if ((void *)clref == (void *)classref)
+          {
+
+            refType = 1;
+            ref = clref;
+
+            // assert(ref);
+
+            break;
+          }
+        }
+
+        if (refType == 0)
+        {
+          for (auto &metaclref : metaclassRefs)
+          {
+            if ((void *)metaclref == (void *)classref)
+            {
+              refType = 2;
+              ref = metaclref;
+              break;
+            }
+          }
+        }
+
+        // assert(refType != 0);
+        const char *className;
+        if (ref == NULL)
+        {
+          className = object_getClassName((id)classref);
+        }
+        else
+        {
+          className = ref->getDataPointer()->getName();
+        }
+        here_objc_class *objcClass = (here_objc_class *)classref;
+        if (refType == 1 && runtimeClasses.count(classref) > 0)
+        {
+          className = objcClass->data()->ro->name;
+        }
+        else if (refType == 2)
+        {
+          Class classForMetaClass = objc_getClass(object_getClassName((id)classref));
+          // assert(classForMetaClass);
+          className = objcClass->data()->ro->name;
+        }
+        // assert(className);
+
+        Class newClz = objc_getClass(className);
+
+        // assert(refType != 0);
+        if (refType == 2)
+        {
+          newClz = objc_getMetaClass(className);
+          // assert(newClz);
+          // assert(class_isMetaClass(newClz));
+        }
+
+        if (*classrefPtr != newClz)
+        {
+          *classrefPtr = newClz;
+        }
+      }
+    }
+
+    void mull::objc::Runtime::addCategoriesFromSection(void *sectionPtr,
+                                                       uintptr_t sectionSize)
+    {
+
+      category_t **categories = (category_t **)sectionPtr;
+      uint32_t count = sectionSize / 8;
+
+      for (uint32_t i = 0; i < count / 2; i++)
+      {
+        category_t *category = categories[i];
+        Class clz = (Class)category->cls;
+        Class metaClz = objc_getMetaClass(class_getName(clz));
+
+        /* Instance methods */
+        const method_list64_t *clzMethodListPtr = (const method_list64_t *)category->instanceMethods;
+        if (clzMethodListPtr)
+        {
+          const method64_t *methods = (const method64_t *)clzMethodListPtr->getFirstMethodPointer();
+
+          for (uint32_t i = 0; i < clzMethodListPtr->count; i++)
+          {
+            const method64_t *methodPtr = &methods[i];
+
+            IMP imp = (IMP)methodPtr->imp;
+
+            BOOL success = class_addMethod(clz,
+                                           sel_registerName(sel_getName(methodPtr->name)),
+                                           (IMP)imp,
+                                           (const char *)methodPtr->types);
+            // assert(success);
+          }
+        }
+
+        /* Class methods */
+        const method_list64_t *metaclassMethodListPtr = (const method_list64_t *)category->classMethods;
+        if (metaclassMethodListPtr)
+        {
+          const method64_t *methods = (const method64_t *)metaclassMethodListPtr->getFirstMethodPointer();
+
+          for (uint32_t i = 0; i < clzMethodListPtr->count; i++)
+          {
+            const method64_t *methodPtr = &methods[i];
+
+            IMP imp = (IMP)methodPtr->imp;
+
+            BOOL success = class_addMethod(metaClz,
+                                           sel_registerName(sel_getName(methodPtr->name)),
+                                           (IMP)imp,
+                                           (const char *)methodPtr->types);
+            // assert(success);
+          }
+        }
+      }
+    }
+
+#pragma mark - Private
+
+    void mull::objc::Runtime::registerClasses()
+    {
+      while (classesToRegister.empty() == false)
+      {
+        class64_t **classrefPtr = classesToRegister.front();
+        class64_t *classref = *classrefPtr;
+        classesToRegister.pop();
+
+        class64_t *superClz64 = classref->getSuperclassPointer();
+        Class superClz = (Class)superClz64;
+        if (objc_classIsRegistered(superClz) == false)
+        {
+          const char *superclzName = superClz64->getDataPointer()->getName();
+          if (Class registeredSuperClz = objc_getClass(superclzName))
+          {
+            superClz = registeredSuperClz;
+          }
+          else
+          {
+
+            classesToRegister.push(classrefPtr);
+            continue;
+          }
+        }
+
+        // assert(superClz);
+
+        Class runtimeClass = registerOneClass(classrefPtr, superClz);
+        // assert(objc_classIsRegistered(runtimeClass));
+
+        runtimeClasses.insert(runtimeClass);
+
+        oldAndNewClassesMap.push_back(std::pair<class64_t **, Class>(classrefPtr, runtimeClass));
+      }
+
+      // assert(classesToRegister.empty());
+    }
+
+    Class mull::objc::Runtime::registerOneClass(class64_t **classrefPtr,
+                                                Class superclass)
+    {
+
+      class64_t *classref = *classrefPtr;
+      class64_t *metaclassRef = classref->getIsaPointer();
+
+      // assert(strlen(classref->getDataPointer()->name) > 0);
+      printf("registerOneClass: %s \n", classref->getDataPointer()->name);
+      printf("\t"
+             "source ptr: 0x%016" PRIxPTR "\n",
+             (uintptr_t)classref);
+      printf("0x%016" PRIXPTR "\n", (uintptr_t)classref);
+
+      classRefs.push_back(classref);
+      metaclassRefs.push_back(metaclassRef);
+
+      if (objc_getClass(classref->getDataPointer()->name) != nullptr)
+      {
+        exit(1);
+      }
+      // assert(objc_classIsRegistered((Class)classref) == false);
+
+      Class runtimeClass = objc_readClassPair((Class)classref, NULL);
+      // assert(runtimeClass);
+
+      // The following might be wrong:
+      // The class is registered by objc_readClassPair but we still hack on its
+      // `flags` below and call objc_registerClassPair to make sure we can dispose
+      // it with objc_disposeClassPair when JIT deallocates.
+      // assert(objc_classIsRegistered((Class)runtimeClass));
+
+      here_objc_class *runtimeClassInternal = (here_objc_class *)runtimeClass;
+      here_objc_class *runtimeMetaclassInternal = (here_objc_class *)runtimeClassInternal->ISA();
+
+#define RW_CONSTRUCTING (1 << 26)
+      here_class_rw_t *sourceClassData = runtimeClassInternal->data();
+      here_class_rw_t *sourceMetaclassData = (here_class_rw_t *)runtimeMetaclassInternal->data();
+      sourceClassData->flags |= RW_CONSTRUCTING;
+      sourceMetaclassData->flags |= RW_CONSTRUCTING;
+      objc_registerClassPair(runtimeClass);
+
+      return runtimeClass;
+    }
+
+  }
+}

--- a/loader/src/custom_dlfcn.cpp
+++ b/loader/src/custom_dlfcn.cpp
@@ -35,188 +35,355 @@
 #import <mach-o/swap.h>
 #import <mach-o/loader.h>
 
+// ObjC Runtime integration
+#include "ObjCRuntime.h"
+#include <vector>
+#include <string>
 
-
-namespace isolator {
-
-// actual definition for opaque type
-struct __NSObjectFileImage
+namespace isolator
 {
-    ImageLoader*    image;
-    const void*        imageBaseAddress;    // not used with OFI created from files
-    size_t            imageLength;        // not used with OFI created from files
-};
-typedef __NSObjectFileImage*  NSObjectFileImage;
 
-static NSModule _dyld_link_module(NSObjectFileImage object_addr, size_t object_size, const char* moduleName, uint32_t options);
+  // actual definition for opaque type
+  struct __NSObjectFileImage
+  {
+    ImageLoader *image;
+    const void *imageBaseAddress; // not used with OFI created from files
+    size_t imageLength;           // not used with OFI created from files
+  };
+  typedef __NSObjectFileImage *NSObjectFileImage;
 
+  static NSModule _dyld_link_module(NSObjectFileImage object_addr, size_t object_size, const char *moduleName, uint32_t options);
 
-extern ImageLoader::LinkContext g_linkContext;
+  extern ImageLoader::LinkContext g_linkContext;
 
-thread_local char* _err_buf = nullptr;
-thread_local size_t _err_buf_size = 0;
+  thread_local char *_err_buf = nullptr;
+  thread_local size_t _err_buf_size = 0;
 
-void clean_error() {
-  if (_err_buf)
-    _err_buf[0] = 0;
-}
-
-void set_dlerror(const std::string &msg) {
-  if (msg.size() >= _err_buf_size) {
+  void clean_error()
+  {
     if (_err_buf)
-      free(_err_buf);
-
-    _err_buf = static_cast<char*>(malloc(msg.size() + 1));
-    _err_buf_size = msg.size() + 1;
+      _err_buf[0] = 0;
   }
-  strcpy(_err_buf, msg.c_str());
-}
 
-static bool is_absolute_path(const char * path) {
-  return path && path[0] == '/';
-}
+  void set_dlerror(const std::string &msg)
+  {
+    if (msg.size() >= _err_buf_size)
+    {
+      if (_err_buf)
+        free(_err_buf);
 
-std::string base_name(const std::string &path) {
-  return path.substr(path.find_last_of("/\\") + 1);
-}
+      _err_buf = static_cast<char *>(malloc(msg.size() + 1));
+      _err_buf_size = msg.size() + 1;
+    }
+    strcpy(_err_buf, msg.c_str());
+  }
 
-void* with_limitation(std::string msg) {
+  static bool is_absolute_path(const char *path)
+  {
+    return path && path[0] == '/';
+  }
+
+  std::string base_name(const std::string &path)
+  {
+    return path.substr(path.find_last_of("/\\") + 1);
+  }
+
+  void *with_limitation(std::string msg)
+  {
     static std::string disclaimer = "\n"
-            "DISCLAIMER: You are using non system mach-o dynamic loader. "
-            "Avoid to using it in production code.\n";
+                                    "DISCLAIMER: You are using non system mach-o dynamic loader. "
+                                    "Avoid to using it in production code.\n";
     set_dlerror("Limitation: " + msg + disclaimer);
     return nullptr;
-}
+  }
 
-void* with_error(std::string msg) {
-  set_dlerror(msg);
-  return nullptr;
-}
+  void *with_error(std::string msg)
+  {
+    set_dlerror(msg);
+    return nullptr;
+  }
 
-extern "C" char* custom_dlerror(void) {
+  // ObjectSectionEntry structure to match ObjCEnabledMemoryManager
+  struct ObjectSectionEntry
+  {
+    uint8_t *pointer;
+    uintptr_t size;
+    std::string section;
+
+    ObjectSectionEntry(uint8_t *pointer,
+                       uintptr_t size,
+                       const std::string &section)
+        : pointer(pointer), size(size), section(section) {}
+  };
+
+  void registerObjC(ImageLoaderMachO *image)
+  {
+    printf("dyld: registerObjC() starting\n");
+
+    // Create ObjC runtime instance
+    mull::objc::Runtime runtime;
+
+    // List of ObjC sections we need to process
+    std::vector<ObjectSectionEntry> objcSections;
+
+    // Define the ObjC sections we need to extract
+    const char *objcSectionNames[] = {
+        "__objc_selrefs",
+        "__objc_classlist",
+        "__objc_classrefs",
+        "__objc_superrefs",
+        "__objc_catlist"};
+
+    // Extract ObjC sections from the ImageLoaderMachO
+    for (const char *sectionName : objcSectionNames)
+    {
+      void *sectionStart = nullptr;
+      size_t sectionSize = 0;
+
+      // Get section content using ImageLoaderMachO's getSectionContent method
+      if (image->getSectionContent("__DATA", sectionName, &sectionStart, &sectionSize))
+      {
+        // printf("dyld: Found ObjC section %s at %p, size: %zu\n", sectionName, sectionStart, sectionSize);
+
+        ObjectSectionEntry entry(static_cast<uint8_t *>(sectionStart),
+                                 sectionSize,
+                                 std::string(sectionName));
+        objcSections.push_back(entry);
+      }
+      else
+      {
+        // Try __DATA_CONST segment as well (used in newer binaries)
+        if (image->getSectionContent("__DATA_CONST", sectionName, &sectionStart, &sectionSize))
+        {
+          // printf("dyld: Found ObjC section %s in __DATA_CONST at %p, size: %zu\n", sectionName, sectionStart, sectionSize);
+
+          ObjectSectionEntry entry(static_cast<uint8_t *>(sectionStart),
+                                   sectionSize,
+                                   std::string(sectionName));
+          objcSections.push_back(entry);
+        }
+      }
+    }
+
+    if (objcSections.empty())
+    {
+      printf("dyld: No ObjC sections found in image\n");
+      return;
+    }
+
+    int numRegisteredClasses = objc_getClassList(NULL, 0);
+    // printf("dyld: ObjC classes before registration: %d\n", numRegisteredClasses);
+
+    // Register selectors first
+    for (ObjectSectionEntry &entry : objcSections)
+    {
+      if (entry.section.find("__objc_selrefs") != std::string::npos)
+      {
+        // printf("dyld: Registering selectors from %s\n", entry.section.c_str());
+        runtime.registerSelectors(entry.pointer, entry.size);
+      }
+    }
+
+    // Add classes from class list
+    for (ObjectSectionEntry &entry : objcSections)
+    {
+      if (entry.section.find("__objc_classlist") != std::string::npos)
+      {
+        // printf("dyld: Adding classes from %s\n", entry.section.c_str());
+        runtime.addClassesFromSection(entry.pointer, entry.size);
+      }
+    }
+
+    // Register all classes
+    printf("dyld: Registering classes\n");
+    runtime.registerClasses();
+
+    // Add class references
+    for (ObjectSectionEntry &entry : objcSections)
+    {
+      if (entry.section.find("__objc_classrefs") != std::string::npos)
+      {
+        // printf("dyld: Adding class references from %s\n", entry.section.c_str());
+        runtime.addClassesFromClassRefsSection(entry.pointer, entry.size);
+      }
+    }
+
+    // Add superclass references
+    for (ObjectSectionEntry &entry : objcSections)
+    {
+      if (entry.section.find("__objc_superrefs") != std::string::npos)
+      {
+        // printf("dyld: Adding superclass references from %s\n", entry.section.c_str());
+        runtime.addClassesFromSuperclassRefsSection(entry.pointer, entry.size);
+      }
+    }
+
+    // Add categories
+    for (ObjectSectionEntry &entry : objcSections)
+    {
+      if (entry.section.find("__objc_catlist") != std::string::npos)
+      {
+        // printf("dyld: Adding categories from %s\n", entry.section.c_str());
+        runtime.addCategoriesFromSection(entry.pointer, entry.size);
+      }
+    }
+
+    printf("dyld: registerObjC() completed\n");
+  }
+
+  extern "C" char *custom_dlerror(void)
+  {
     if (_err_buf && _err_buf[0] == 0)
-        return nullptr;
+      return nullptr;
 
     return _err_buf;
-}
-
-extern "C" void* custom_dlopen(const char * __path, int __mode) {
-  try {
-    clean_error();
-    if (!is_absolute_path(__path))
-      return with_limitation("Only absolute path is supported. Please specify "
-                             "full path to binary.");
-
-    std::fstream lib_f(__path, std::ios::in | std::ios::binary);
-    if (!lib_f.is_open())
-      return with_error("File does not exist.");
-
-    std::streampos fsize = lib_f.tellg();
-    lib_f.seekg(0, std::ios::end);
-    fsize = lib_f.tellg() - fsize;
-    lib_f.seekg(0, std::ios::beg);
-
-    std::vector<char> buff(fsize);
-    lib_f.read(buff.data(), fsize);
-    lib_f.close();
-
-    std::string file_name = base_name(__path);
-    auto mh = reinterpret_cast<const macho_header*>(buff.data());
-      
-    // Load image step
-    auto image = ImageLoaderMachO::instantiateFromMemory(file_name.c_str(), mh, fsize, g_linkContext);
-      
-    bool forceLazysBound = true;
-    bool preflightOnly = false;
-    bool neverUnload = false;
-
-    // Link step
-    std::vector<const char*> rpaths;
-    ImageLoader::RPathChain loaderRPaths(NULL, &rpaths);
-    image->link(g_linkContext, forceLazysBound, preflightOnly, neverUnload, loaderRPaths, __path);
-      
-    
-    // Initialization of static objects step
-    ImageLoader::InitializerTimingList initializerTimes[1];
-    initializerTimes[0].count = 0;
-    image->runInitializers(g_linkContext, initializerTimes[0]);
-
-      
-    return image;
-  } catch (const char * msg) {
-      printf("custom_dlopen: error %s\n", msg);
-      
-    return with_error("Error happens during dlopen execution. " + std::string(msg));
-  } catch (...) {
-      printf("custom_dlopen: error ??\n");
-      
-    return with_error("Error happens during dlopen execution. Unknown reason...");
   }
-}
 
-extern "C" void* custom_dlopen_from_memory(void* mh, int len) {
-  
-    const char * path = "foobar";
-    
-    // Load image step
-    auto image = ImageLoaderMachO::instantiateFromMemory(path, (macho_header*)mh, len, g_linkContext);
-      
-    printf("dyld: 'ImageLoaderMachO::instantiateFromMemory' completed (image addr: %p)\n", image);
+  extern "C" void *custom_dlopen(const char *__path, int __mode)
+  {
+    try
+    {
+      clean_error();
+      if (!is_absolute_path(__path))
+        return with_limitation("Only absolute path is supported. Please specify "
+                               "full path to binary.");
 
-    bool forceLazysBound = true;
-    bool preflightOnly = false;
-    bool neverUnload = false;
+      std::fstream lib_f(__path, std::ios::in | std::ios::binary);
+      if (!lib_f.is_open())
+        return with_error("File does not exist.");
 
-    // Link step
-    std::vector<const char*> rpaths;
-    ImageLoader::RPathChain loaderRPaths(NULL, &rpaths);
-    image->link(g_linkContext, forceLazysBound, preflightOnly, neverUnload, loaderRPaths, path);
-    
-    printf("dyld: 'image->link' completed\n");
-    
-    // Initialization of static objects step
-    ImageLoader::InitializerTimingList initializerTimes[1];
-    initializerTimes[0].count = 0;
-    image->runInitializers(g_linkContext, initializerTimes[0]);
-    
-    printf("dyld: 'image->runInitializers' completed\n");
+      std::streampos fsize = lib_f.tellg();
+      lib_f.seekg(0, std::ios::end);
+      fsize = lib_f.tellg() - fsize;
+      lib_f.seekg(0, std::ios::beg);
 
-    return image;
-  
-}
+      std::vector<char> buff(fsize);
+      lib_f.read(buff.data(), fsize);
+      lib_f.close();
 
+      std::string file_name = base_name(__path);
+      auto mh = reinterpret_cast<const macho_header *>(buff.data());
 
-extern "C" void* custom_dlsym(void * __handle, const char * __symbol) {
-  try {
-    clean_error();
+      // Load image step
+      auto image = ImageLoaderMachO::instantiateFromMemory(file_name.c_str(), mh, fsize, g_linkContext);
 
-    std::string underscoredName = "_" + std::string(__symbol);
-    const ImageLoader* image = reinterpret_cast<ImageLoader*>(__handle);
+      bool forceLazysBound = true;
+      bool preflightOnly = false;
+      bool neverUnload = false;
 
-    auto sym = image->findExportedSymbol(underscoredName.c_str(), true, &image);
-    if (sym != NULL) {
-      auto addr = image->getExportedSymbolAddress(sym, g_linkContext, nullptr, false,
-                                                  underscoredName.c_str());
-      return reinterpret_cast<void*>(addr);
+      // Link step
+      std::vector<const char *> rpaths;
+      ImageLoader::RPathChain loaderRPaths(NULL, &rpaths);
+      image->link(g_linkContext, forceLazysBound, preflightOnly, neverUnload, loaderRPaths, __path);
+
+      // Initialization of static objects step
+      ImageLoader::InitializerTimingList initializerTimes[1];
+      initializerTimes[0].count = 0;
+      image->runInitializers(g_linkContext, initializerTimes[0]);
+
+      return image;
     }
-    return with_error("Symbol " + std::string(__symbol) + " is not found.");
-  } catch (const char * msg) {
-    return with_error("Error happens during dlsym execution. " + std::string(msg));
-  } catch (...) {
-    return with_error("Error happens during dlsym execution. Unknown reason...");
-  }
-}
+    catch (const char *msg)
+    {
+      printf("custom_dlopen: error %s\n", msg);
 
-extern "C" int custom_dlclose(void * __handle) {
-  if (__handle == nullptr) {
-    set_dlerror("Error happens during dlclose execution. Handle does not refer "
-                "to an open object.");
-    return -1;
-  }
-  ImageLoader* image = reinterpret_cast<ImageLoader*>(__handle);
-  ImageLoader::deleteImage(image);
-  return 0;
-}
+      return with_error("Error happens during dlopen execution. " + std::string(msg));
+    }
+    catch (...)
+    {
+      printf("custom_dlopen: error ??\n");
 
+      return with_error("Error happens during dlopen execution. Unknown reason...");
+    }
+  }
+
+  extern "C" void *custom_dlopen_from_memory(void *mh, int len)
+  {
+    try
+    {
+      const char *path = "foobar";
+
+      // Load image step
+      auto image = ImageLoaderMachO::instantiateFromMemory(path, (macho_header *)mh, len, g_linkContext);
+
+      printf("dyld: 'ImageLoaderMachO::instantiateFromMemory' completed (image addr: %p)\n", image);
+
+      bool forceLazysBound = true;
+      bool preflightOnly = false;
+      bool neverUnload = false;
+
+      // Link step
+      std::vector<const char *> rpaths;
+      ImageLoader::RPathChain loaderRPaths(NULL, &rpaths);
+      image->link(g_linkContext, forceLazysBound, preflightOnly, neverUnload, loaderRPaths, path);
+
+      printf("dyld: 'image->link' completed\n");
+
+      // Register ObjC classes step
+      registerObjC(static_cast<ImageLoaderMachO *>(image));
+
+      // Initialization of static objects step
+      ImageLoader::InitializerTimingList initializerTimes[1];
+      initializerTimes[0].count = 0;
+      image->runInitializers(g_linkContext, initializerTimes[0]);
+
+      printf("dyld: 'image->runInitializers' completed\n");
+
+      return image;
+    }
+    catch (const char *msg)
+    {
+      printf("custom_dlopen_from_memory: error %s\n", msg);
+
+      return with_error("Error happens during custom_dlopen_from_memory execution. " + std::string(msg));
+    }
+    catch (...)
+    {
+      printf("custom_dlopen_from_memory: error ??\n");
+
+      return with_error("Error happens during custom_dlopen_from_memory execution. Unknown reason...");
+    }
+  }
+
+  extern "C" void *custom_dlsym(void *__handle, const char *__symbol)
+  {
+    try
+    {
+      clean_error();
+
+      std::string underscoredName = "_" + std::string(__symbol);
+      const ImageLoader *image = reinterpret_cast<ImageLoader *>(__handle);
+
+      auto sym = image->findExportedSymbol(underscoredName.c_str(), true, &image);
+      if (sym != NULL)
+      {
+        auto addr = image->getExportedSymbolAddress(sym, g_linkContext, nullptr, false,
+                                                    underscoredName.c_str());
+        return reinterpret_cast<void *>(addr);
+      }
+      return with_error("Symbol " + std::string(__symbol) + " is not found.");
+    }
+    catch (const char *msg)
+    {
+      return with_error("Error happens during dlsym execution. " + std::string(msg));
+    }
+    catch (...)
+    {
+      return with_error("Error happens during dlsym execution. Unknown reason...");
+    }
+  }
+
+  extern "C" int custom_dlclose(void *__handle)
+  {
+    if (__handle == nullptr)
+    {
+      set_dlerror("Error happens during dlclose execution. Handle does not refer "
+                  "to an open object.");
+      return -1;
+    }
+    ImageLoader *image = reinterpret_cast<ImageLoader *>(__handle);
+    ImageLoader::deleteImage(image);
+    return 0;
+  }
 
 } // namespace isolator


### PR DESCRIPTION
Ported code from the [Github project](https://github.com/mull-project/llvm-jit-objc) referenced in this [article ](https://stanislaw.github.io/2018-09-03-llvm-jit-objc-and-swift-knowledge-dump.html) to add support for loading ObjC and Swift libraries in memory.